### PR TITLE
bugfix. while setting identity type, it was previously not possible to be an entity seller

### DIFF
--- a/bzst-dip-java-client/src/main/java/software/xdev/bzst/dip/client/model/message/BzstDipCorrectableReportableSellerType.java
+++ b/bzst-dip-java-client/src/main/java/software/xdev/bzst/dip/client/model/message/BzstDipCorrectableReportableSellerType.java
@@ -51,7 +51,7 @@ public record BzstDipCorrectableReportableSellerType(
 			this.vat,
 			this.firstName,
 			this.lastName,
-			this.birthDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
+			this.birthDate == null ? "NULL" : this.birthDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
 			this.legalAddress.toXmlType(),
 			this.addressFix.toXmlType(),
 			this.numberOfActivities.toXmlType(),


### PR DESCRIPTION
This is the mechanism to determine the identity of the reportable ressource.

```
	private static ReportableSellerType.Identity createIdentity(
		final CountryCodeType resCountryCode,
		final TINType tin,
		final String in,
		final String vat,
		final String firstName,
		final String lastName,
		final AddressFixType addressFixType,
		final OECDLegalAddressTypeEnumType legalAddressTypeEnumType,
		final String birthDate,
		final String permanentEstablishments
	)
	{
		final ReportableSellerType.Identity identity = new ReportableSellerType.Identity();
		if(isNULLAsString(firstName) && isNULLAsString(birthDate)) {
                      ...
         }
```

```
	public static boolean isNULLAsString(final String checkNULLString)
	{
		return checkNULLString.equals("NULL");
	}
```

The old conversation from DateTime to String made it impossible for the string to be "NULL".

```
this.birthDate.format(DateTimeFormatter.ISO_LOCAL_DATE)
```